### PR TITLE
Small fixes

### DIFF
--- a/ne16/hal/ne16_task.c
+++ b/ne16/hal/ne16_task.c
@@ -206,8 +206,8 @@ void ne16_task_set_padding(ne16_task_t *task, const uint8_t top,
 }
 
 void ne16_task_set_mask_filter(ne16_task_t *task, const uint8_t top,
-                               const uint8_t right, const uint8_t bottom,
-                               const uint8_t left) {
+                               const uint8_t bottom, const uint8_t left,
+                               const uint8_t right) {
   task->data.cfg.filter_mask = ((top & 0xff) << 24) | ((right & 0xff) << 16) |
                                ((bottom & 0xff) << 8) | ((left & 0xff) << 0);
 }
@@ -219,8 +219,8 @@ void ne16_task_set_dims(ne16_task_t *task, const uint32_t w_in,
                         const uint32_t h_out_stride,
                         const uint32_t w_out_stride, const uint8_t padding_top,
                         const uint8_t padding_bottom,
-                        const uint8_t padding_right,
-                        const uint8_t padding_left) {
+                        const uint8_t padding_left,
+                        const uint8_t padding_right) {
   ne16_task_set_strides(task, k_in, h_in_stride, w_in_stride, h_out_stride,
                         w_out_stride);
   ne16_task_set_counters(task, k_in, h_out, w_out, k_out, padding_bottom,
@@ -235,8 +235,8 @@ void ne16_task_set_dims_stride2x2(
     const uint32_t h_out, const uint32_t w_out, const uint32_t k_out,
     const uint32_t h_out_stride, const uint32_t w_out_stride,
     const uint8_t h_ker, const uint8_t w_ker, const uint8_t padding_top,
-    const uint8_t padding_bottom, const uint8_t padding_right,
-    const uint8_t padding_left) {
+    const uint8_t padding_bottom, const uint8_t padding_left,
+    const uint8_t padding_right) {
   const uint8_t stride = 2;
 
   // WARNING: works only for even output channel stride (divisible by 2)

--- a/ne16/hal/ne16_task.h
+++ b/ne16/hal/ne16_task.h
@@ -157,8 +157,8 @@ void ne16_task_set_padding(ne16_task_t *task, const uint8_t top,
                            const uint8_t bottom, const uint8_t left,
                            const uint8_t right, const uint8_t value);
 void ne16_task_set_mask_filter(ne16_task_t *task, const uint8_t top,
-                               const uint8_t right, const uint8_t bottom,
-                               const uint8_t left);
+                               const uint8_t bottom, const uint8_t left,
+                               const uint8_t right);
 /** ne16_task_set_dims
  *
  * All the strides variables are strides between elements alongside that
@@ -172,8 +172,8 @@ void ne16_task_set_dims(ne16_task_t *task, const uint32_t w_in,
                         const uint32_t h_out_stride,
                         const uint32_t w_out_stride, const uint8_t padding_top,
                         const uint8_t padding_bottom,
-                        const uint8_t padding_right,
-                        const uint8_t padding_left);
+                        const uint8_t padding_left,
+                        const uint8_t padding_right);
 /** ne16_task_set_dims_stride2x2
  *
  * All the strides variables are strides between elements alongside that
@@ -186,7 +186,7 @@ void ne16_task_set_dims_stride2x2(
     const uint32_t h_out, const uint32_t w_out, const uint32_t k_out,
     const uint32_t h_out_stride, const uint32_t w_out_stride,
     const uint8_t h_ker, const uint8_t w_ker, const uint8_t padding_top,
-    const uint8_t padding_bottom, const uint8_t padding_right,
-    const uint8_t padding_left);
+    const uint8_t padding_bottom, const uint8_t padding_left,
+    const uint8_t padding_right);
 
 #endif // !__NE16_TASK_H__

--- a/ne16/hal/ne16_task.h
+++ b/ne16/hal/ne16_task.h
@@ -42,8 +42,8 @@ typedef enum {
 
 typedef struct ne16_norm_t {
   ne16_norm_mode_e mode;
-  int flag_bias;
-  int flag_shift;
+  ne16_task_flag_e flag_bias;
+  ne16_task_flag_e flag_shift;
 } ne16_norm_t;
 
 typedef enum ne16_quant_mode_e {
@@ -59,9 +59,9 @@ typedef enum ne16_quant_function_e {
 
 typedef struct ne16_quant_t {
   // Shift amount must be in range 0x00-0x1F
-  unsigned shift_amount;
+  uint8_t shift_amount;
   ne16_quant_function_e function;
-  int flag_rounding;
+  ne16_task_flag_e flag_rounding;
 } ne16_quant_t;
 
 typedef struct ne16_stride_t {

--- a/neureka/bsp/neureka_siracusa_bsp.h
+++ b/neureka/bsp/neureka_siracusa_bsp.h
@@ -18,8 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __NEUREKA_siracusa_BSP_H__
-#define __NEUREKA_siracusa_BSP_H__
+#ifndef __NEUREKA_SIRACUSA_BSP_H__
+#define __NEUREKA_SIRACUSA_BSP_H__
 
 #include "neureka.h"
 #include <stdint.h>
@@ -64,4 +64,4 @@ void neureka_siracusa_close();
 void neureka_siracusa_event_wait_and_clear();
 const neureka_dev_t *neureka_siracusa_get_dev();
 
-#endif // !__NEUREKA_siracusa_BSP_H__
+#endif // !__NEUREKA_SIRACUSA_BSP_H__

--- a/neureka/hal/neureka_task.c
+++ b/neureka/hal/neureka_task.c
@@ -47,8 +47,7 @@ void neureka_task_init(neureka_task_t *task) {
 
 void neureka_task_set_op_to_conv(neureka_task_t *task,
                                  const uint8_t kernel_shape,
-                                 const uint8_t depthwise,
-                                 const uint8_t stride) {
+                                 const uint8_t depthwise) {
   task->depthwise = depthwise;
   task->kernel_shape = kernel_shape;
   task->subtile_output_channel = depthwise ? NEUREKA_SUBTILE_INPUT_CHANNEL_3x3

--- a/neureka/hal/neureka_task.c
+++ b/neureka/hal/neureka_task.c
@@ -216,8 +216,8 @@ void neureka_task_set_padding(neureka_task_t *task, const uint8_t top,
 }
 
 void neureka_task_set_mask_filter(neureka_task_t *task, const uint8_t top,
-                                  const uint8_t right, const uint8_t bottom,
-                                  const uint8_t left) {
+                                  const uint8_t bottom, const uint8_t left,
+                                  const uint8_t right) {
   task->data.cfg.filter_mask = ((top & 0xff) << 24) | ((right & 0xff) << 16) |
                                ((bottom & 0xff) << 8) | ((left & 0xff) << 0);
 }
@@ -228,7 +228,7 @@ void neureka_task_set_dims(
     const uint32_t h_out, const uint32_t w_out, const uint32_t k_out,
     const uint32_t h_out_stride, const uint32_t w_out_stride,
     const uint8_t padding_top, const uint8_t padding_bottom,
-    const uint8_t padding_right, const uint8_t padding_left) {
+    const uint8_t padding_left, const uint8_t padding_right) {
   neureka_task_set_strides(task, k_in, h_in_stride, w_in_stride, h_out_stride,
                            w_out_stride);
   neureka_task_set_counters(task, k_in, h_out, w_out, k_out, padding_bottom,

--- a/neureka/hal/neureka_task.h
+++ b/neureka/hal/neureka_task.h
@@ -46,8 +46,8 @@ typedef enum {
 
 typedef struct neureka_norm_t {
   neureka_norm_mode_e mode;
-  int flag_bias;
-  int flag_shift;
+  neureka_task_flag_e flag_bias;
+  neureka_task_flag_e flag_shift;
 } neureka_norm_t;
 
 typedef enum neureka_quant_mode_e {
@@ -62,9 +62,9 @@ typedef enum neureka_quant_function_e {
 
 typedef struct neureka_quant_t {
   // Shift amount must be in range 0x00-0x1F
-  unsigned shift_amount;
+  uint8_t shift_amount;
   neureka_quant_function_e function;
-  int flag_rounding;
+  neureka_task_flag_e flag_rounding;
 } neureka_quant_t;
 
 typedef struct neureka_stride_t {

--- a/neureka/hal/neureka_task.h
+++ b/neureka/hal/neureka_task.h
@@ -123,7 +123,7 @@ typedef struct neureka_task_t {
 void neureka_task_init(neureka_task_t *task);
 void neureka_task_set_op_to_conv(neureka_task_t *task,
                                  const uint8_t kernel_shape,
-                                 const uint8_t depthwise, const uint8_t stride);
+                                 const uint8_t depthwise);
 void neureka_task_set_bits(neureka_task_t *task, const uint8_t input_bits,
                            const uint8_t output_bits,
                            const uint8_t weight_bits);

--- a/neureka/hal/neureka_task.h
+++ b/neureka/hal/neureka_task.h
@@ -168,8 +168,8 @@ void neureka_task_set_padding(neureka_task_t *task, const uint8_t top,
                               const uint8_t bottom, const uint8_t left,
                               const uint8_t right, const uint8_t value);
 void neureka_task_set_mask_filter(neureka_task_t *task, const uint8_t top,
-                                  const uint8_t right, const uint8_t bottom,
-                                  const uint8_t left);
+                                  const uint8_t bottom, const uint8_t left,
+                                  const uint8_t right);
 /** neureka_task_set_dims
  *
  * All the strides variables are strides between elements alongside that
@@ -182,6 +182,6 @@ void neureka_task_set_dims(
     const uint32_t h_out, const uint32_t w_out, const uint32_t k_out,
     const uint32_t h_out_stride, const uint32_t w_out_stride,
     const uint8_t padding_top, const uint8_t padding_bottom,
-    const uint8_t padding_right, const uint8_t padding_left);
+    const uint8_t padding_left, const uint8_t padding_right);
 
 #endif // !__NEUREKA_TASK_H__

--- a/test/app/src/nnx_layer.c
+++ b/test/app/src/nnx_layer.c
@@ -113,7 +113,11 @@ typedef neureka_siracusa_conf_t nnx_bsp_conf_t;
 
 static void task_prepare(nnx_task_t *task) {
   nnx_task_init(task);
+#ifdef NNX_NEUREKA
+  nnx_task_set_op_to_conv(task, WEIGHT_HEIGHT, GROUPS > 1);
+#else
   nnx_task_set_op_to_conv(task, WEIGHT_HEIGHT, GROUPS > 1, STRIDE_HEIGHT);
+#endif
   nnx_task_set_bits(task, INPUT_BITS, OUTPUT_BITS, WEIGHT_BITS);
 
 #if HAS_NORM_QUANT == 1

--- a/test/app/src/nnx_layer.c
+++ b/test/app/src/nnx_layer.c
@@ -162,13 +162,13 @@ static void task_prepare(nnx_task_t *task) {
   nnx_task_set_dims_stride2x2(
       task, INPUT_HEIGHT, INPUT_WIDTH, INPUT_CHANNEL, h_in_stride, w_in_stride,
       OUTPUT_HEIGHT, OUTPUT_WIDTH, OUTPUT_CHANNEL, h_out_stride, w_out_stride,
-      WEIGHT_HEIGHT, WEIGHT_WIDTH, PADDING_TOP, PADDING_BOTTOM, PADDING_RIGHT,
-      PADDING_LEFT);
+      WEIGHT_HEIGHT, WEIGHT_WIDTH, PADDING_TOP, PADDING_BOTTOM, PADDING_LEFT,
+      PADDING_RIGHT);
 #else
   nnx_task_set_dims(task, INPUT_WIDTH, INPUT_CHANNEL, h_in_stride, w_in_stride,
                     OUTPUT_HEIGHT, OUTPUT_WIDTH, OUTPUT_CHANNEL, h_out_stride,
-                    w_out_stride, PADDING_TOP, PADDING_BOTTOM, PADDING_RIGHT,
-                    PADDING_LEFT);
+                    w_out_stride, PADDING_TOP, PADDING_BOTTOM, PADDING_LEFT,
+                    PADDING_RIGHT);
 #endif
 
   nnx_task_set_ptrs(task, (uint32_t)input, INPUT_WIDTH, w_in_stride,


### PR DESCRIPTION
I fixed a few inconsistencies:
- stride was still an argument for neureka_task_set_op_to_conv, even though it's not used
- norm, quant structures didn't have bitwidths specified
- padding dim order to top, bottom, left, right