### PR TITLE
Split normquant ptrs

### DIFF
--- a/ne16/hal/ne16_task.c
+++ b/ne16/hal/ne16_task.c
@@ -113,15 +113,18 @@ uint32_t ne16_pad_ptr(uint32_t ptr, const uint32_t width, uint32_t width_stride,
   return ptr - (padding_top * width + padding_left) * width_stride;
 }
 
-void ne16_task_set_ptrs(ne16_task_t *task, uint32_t input_ptr, uint32_t w_in,
-                        uint32_t w_in_stride, uint8_t padding_top,
-                        uint8_t padding_left, uint32_t output_ptr,
-                        uint32_t weights_ptr, uint32_t scale_ptr,
-                        uint32_t shift_ptr, uint32_t bias_ptr) {
+void ne16_task_set_ptrs_conv(ne16_task_t *task, uint32_t input_ptr,
+                             uint32_t w_in, uint32_t w_in_stride,
+                             uint8_t padding_top, uint8_t padding_left,
+                             uint32_t output_ptr, uint32_t weights_ptr) {
   task->data.infeat_ptr =
       ne16_pad_ptr(input_ptr, w_in, w_in_stride, padding_top, padding_left);
   task->data.outfeat_ptr = output_ptr;
   task->data.weights_ptr = weights_ptr;
+}
+
+void ne16_task_set_ptrs_norm_quant(ne16_task_t *task, uint32_t scale_ptr,
+                                   uint32_t shift_ptr, uint32_t bias_ptr) {
   task->data.scale_ptr = scale_ptr;
   task->data.scale_shift_ptr = shift_ptr;
   task->data.scale_bias_ptr = bias_ptr;

--- a/ne16/hal/ne16_task.h
+++ b/ne16/hal/ne16_task.h
@@ -133,11 +133,12 @@ uint32_t ne16_get_tile_padding(uint32_t padding, uint32_t i_height,
 uint32_t ne16_pad_ptr(uint32_t ptr, const uint32_t width,
                       const uint32_t width_stride, const uint8_t padding_top,
                       const uint8_t padding_left);
-void ne16_task_set_ptrs(ne16_task_t *task, uint32_t input_ptr, uint32_t w_in,
-                        uint32_t w_in_stride, uint8_t padding_top,
-                        uint8_t padding_left, uint32_t output_ptr,
-                        uint32_t weights_ptr, uint32_t scale_ptr,
-                        uint32_t shift_ptr, uint32_t bias_ptr);
+void ne16_task_set_ptrs_conv(ne16_task_t *task, uint32_t input_ptr,
+                             uint32_t w_in, uint32_t w_in_stride,
+                             uint8_t padding_top, uint8_t padding_left,
+                             uint32_t output_ptr, uint32_t weights_ptr);
+void ne16_task_set_ptrs_norm_quant(ne16_task_t *task, uint32_t scale_ptr,
+                                   uint32_t shift_ptr, uint32_t bias_ptr);
 /** ne16_task_set_strides
  *
  * All the strides variables are strides between elements alongside that

--- a/neureka/hal/neureka_task.c
+++ b/neureka/hal/neureka_task.c
@@ -126,16 +126,18 @@ uint32_t neureka_pad_ptr(uint32_t ptr, const uint32_t width,
   return ptr - (padding_top * width + padding_left) * width_stride;
 }
 
-void neureka_task_set_ptrs(neureka_task_t *task, uint32_t input_ptr,
-                           uint32_t w_in, uint32_t w_in_stride,
-                           uint8_t padding_top, uint8_t padding_left,
-                           uint32_t output_ptr, uint32_t weights_ptr,
-                           uint32_t scale_ptr, uint32_t shift_ptr,
-                           uint32_t bias_ptr) {
+void neureka_task_set_ptrs_conv(neureka_task_t *task, uint32_t input_ptr,
+                                uint32_t w_in, uint32_t w_in_stride,
+                                uint8_t padding_top, uint8_t padding_left,
+                                uint32_t output_ptr, uint32_t weights_ptr) {
   task->data.infeat_ptr =
       neureka_pad_ptr(input_ptr, w_in, w_in_stride, padding_top, padding_left);
   task->data.outfeat_ptr = output_ptr;
   task->data.weights_ptr = weights_ptr;
+}
+
+void neureka_task_set_ptrs_norm_quant(neureka_task_t *task, uint32_t scale_ptr,
+                                      uint32_t shift_ptr, uint32_t bias_ptr) {
   task->data.scale_ptr = scale_ptr;
   task->data.scale_shift_ptr = shift_ptr;
   task->data.scale_bias_ptr = bias_ptr;

--- a/neureka/hal/neureka_task.h
+++ b/neureka/hal/neureka_task.h
@@ -142,12 +142,12 @@ uint32_t neureka_get_tile_padding(uint32_t padding, uint32_t i_height,
 uint32_t neureka_pad_ptr(uint32_t ptr, const uint32_t width,
                          const uint32_t width_stride, const uint8_t padding_top,
                          const uint8_t padding_left);
-void neureka_task_set_ptrs(neureka_task_t *task, uint32_t input_ptr,
-                           uint32_t w_in, uint32_t w_in_stride,
-                           uint8_t padding_top, uint8_t padding_left,
-                           uint32_t output_ptr, uint32_t weights_ptr,
-                           uint32_t scale_ptr, uint32_t shift_ptr,
-                           uint32_t bias_ptr);
+void neureka_task_set_ptrs_conv(neureka_task_t *task, uint32_t input_ptr,
+                                uint32_t w_in, uint32_t w_in_stride,
+                                uint8_t padding_top, uint8_t padding_left,
+                                uint32_t output_ptr, uint32_t weights_ptr);
+void neureka_task_set_ptrs_norm_quant(neureka_task_t *task, uint32_t scale_ptr,
+                                      uint32_t shift_ptr, uint32_t bias_ptr);
 /** neureka_task_set_strides
  *
  * All the strides variables are strides between elements alongside that

--- a/test/NeurekaMemoryLayout.py
+++ b/test/NeurekaMemoryLayout.py
@@ -20,8 +20,6 @@
 import numpy as np
 import numpy.typing as npt
 
-from TestClasses import IntegerType
-
 
 class NeurekaMemoryLayout:
     _WEIGHT_BANDWIDTH = 256


### PR DESCRIPTION
Split the `set_ptrs` function into `set_ptrs_conv` and `set_ptrs_norm_quant` so that setting the normquant pointers can be omitted for normquantless kernels.