### PR TITLE
Change the wmem field to be required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Changed
 
+- the `wmem` field in the test configurations is now required
 - `ne16_task_init` got split into smaller parts: `ne16_task_init`, `ne16_task_set_op_to_conv`, `ne16_task_set_weight_offset`, `ne16_task_set_bits`, `ne16_task_set_norm_quant`
 - strides in `ne16_task_set_strides`, `ne16_task_set_dims`, and `ne16_task_set_ptrs` are now strides between consecutive elements in that dimension
 - `ne16_task_queue_size` is now `NE16_TASK_QUEUE_SIZE`

--- a/test/NnxTestClasses.py
+++ b/test/NnxTestClasses.py
@@ -50,7 +50,7 @@ class NnxTestConf(BaseModel):
     has_norm_quant: bool
     has_bias: bool
     has_relu: bool
-    wmem: WmemLiteral = "tcdm"
+    wmem: WmemLiteral
 
     @model_validator(mode="after")  # type: ignore
     def check_valid_depthwise_channels(self) -> NnxTestConf:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -109,7 +109,10 @@ def pytest_generate_tests(metafunc):
                 test.save_data(test_dir)
             nnxTestAndNames.append((test, test_dir))
         except pydantic.ValidationError as e:
-            _ = e
+            for error in e.errors():
+                if error["type"] == "missing":
+                    raise e
+
             nnxTestAndNames.append(
                 pytest.param(
                     (None, test_dir),

--- a/test/tests/test_0/conf.json
+++ b/test/tests/test_0/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_1/conf.json
+++ b/test/tests/test_1/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_10/conf.json
+++ b/test/tests/test_10/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_100/conf.json
+++ b/test/tests/test_100/conf.json
@@ -25,5 +25,6 @@
     "bias_type": "int32",
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": true
+    "has_relu": true,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_101/conf.json
+++ b/test/tests/test_101/conf.json
@@ -25,5 +25,6 @@
     "bias_type": "int32",
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": true
+    "has_relu": true,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_102/conf.json
+++ b/test/tests/test_102/conf.json
@@ -25,5 +25,6 @@
     "bias_type": "int32",
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": true
+    "has_relu": true,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_103/conf.json
+++ b/test/tests/test_103/conf.json
@@ -25,5 +25,6 @@
     "bias_type": "int32",
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": true
+    "has_relu": true,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_104/conf.json
+++ b/test/tests/test_104/conf.json
@@ -25,5 +25,6 @@
     "bias_type": "int32",
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": true
+    "has_relu": true,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_105/conf.json
+++ b/test/tests/test_105/conf.json
@@ -25,5 +25,6 @@
     "bias_type": "int32",
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": true
+    "has_relu": true,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_106/conf.json
+++ b/test/tests/test_106/conf.json
@@ -25,5 +25,6 @@
     "bias_type": "int32",
     "has_norm_quant": false,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_107/conf.json
+++ b/test/tests/test_107/conf.json
@@ -25,5 +25,6 @@
     "bias_type": "int32",
     "has_norm_quant": false,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_108/conf.json
+++ b/test/tests/test_108/conf.json
@@ -25,5 +25,6 @@
     "bias_type": "int32",
     "has_norm_quant": false,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_109/conf.json
+++ b/test/tests/test_109/conf.json
@@ -25,5 +25,6 @@
     "bias_type": "int32",
     "has_norm_quant": false,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_11/conf.json
+++ b/test/tests/test_11/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_110/conf.json
+++ b/test/tests/test_110/conf.json
@@ -25,5 +25,6 @@
     "bias_type": "int32",
     "has_norm_quant": false,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_111/conf.json
+++ b/test/tests/test_111/conf.json
@@ -25,5 +25,6 @@
     "bias_type": "int32",
     "has_norm_quant": false,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_112/conf.json
+++ b/test/tests/test_112/conf.json
@@ -25,5 +25,6 @@
     "bias_type": "int32",
     "has_norm_quant": false,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_113/conf.json
+++ b/test/tests/test_113/conf.json
@@ -25,5 +25,6 @@
     "bias_type": "int32",
     "has_norm_quant": false,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_114/conf.json
+++ b/test/tests/test_114/conf.json
@@ -25,5 +25,6 @@
     "bias_type": "int32",
     "has_norm_quant": false,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_115/conf.json
+++ b/test/tests/test_115/conf.json
@@ -25,5 +25,6 @@
     "bias_type": "int32",
     "has_norm_quant": false,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_116/conf.json
+++ b/test/tests/test_116/conf.json
@@ -25,5 +25,6 @@
     "bias_type": "int32",
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_117/conf.json
+++ b/test/tests/test_117/conf.json
@@ -25,5 +25,6 @@
     "bias_type": "int32",
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_118/conf.json
+++ b/test/tests/test_118/conf.json
@@ -25,5 +25,6 @@
     "bias_type": "int32",
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_12/conf.json
+++ b/test/tests/test_12/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_13/conf.json
+++ b/test/tests/test_13/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_14/conf.json
+++ b/test/tests/test_14/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_15/conf.json
+++ b/test/tests/test_15/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_16/conf.json
+++ b/test/tests/test_16/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_17/conf.json
+++ b/test/tests/test_17/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_18/conf.json
+++ b/test/tests/test_18/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_19/conf.json
+++ b/test/tests/test_19/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_2/conf.json
+++ b/test/tests/test_2/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_20/conf.json
+++ b/test/tests/test_20/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_21/conf.json
+++ b/test/tests/test_21/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_22/conf.json
+++ b/test/tests/test_22/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_23/conf.json
+++ b/test/tests/test_23/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_24/conf.json
+++ b/test/tests/test_24/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_25/conf.json
+++ b/test/tests/test_25/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_26/conf.json
+++ b/test/tests/test_26/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_27/conf.json
+++ b/test/tests/test_27/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_28/conf.json
+++ b/test/tests/test_28/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_29/conf.json
+++ b/test/tests/test_29/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_3/conf.json
+++ b/test/tests/test_3/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_30/conf.json
+++ b/test/tests/test_30/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_31/conf.json
+++ b/test/tests/test_31/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_32/conf.json
+++ b/test/tests/test_32/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_33/conf.json
+++ b/test/tests/test_33/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_34/conf.json
+++ b/test/tests/test_34/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_35/conf.json
+++ b/test/tests/test_35/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_36/conf.json
+++ b/test/tests/test_36/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_37/conf.json
+++ b/test/tests/test_37/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_38/conf.json
+++ b/test/tests/test_38/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_39/conf.json
+++ b/test/tests/test_39/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_4/conf.json
+++ b/test/tests/test_4/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_40/conf.json
+++ b/test/tests/test_40/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_41/conf.json
+++ b/test/tests/test_41/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_42/conf.json
+++ b/test/tests/test_42/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_43/conf.json
+++ b/test/tests/test_43/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_44/conf.json
+++ b/test/tests/test_44/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_45/conf.json
+++ b/test/tests/test_45/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_46/conf.json
+++ b/test/tests/test_46/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_47/conf.json
+++ b/test/tests/test_47/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_48/conf.json
+++ b/test/tests/test_48/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_49/conf.json
+++ b/test/tests/test_49/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_5/conf.json
+++ b/test/tests/test_5/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_50/conf.json
+++ b/test/tests/test_50/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_51/conf.json
+++ b/test/tests/test_51/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_52/conf.json
+++ b/test/tests/test_52/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_53/conf.json
+++ b/test/tests/test_53/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_54/conf.json
+++ b/test/tests/test_54/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_55/conf.json
+++ b/test/tests/test_55/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_56/conf.json
+++ b/test/tests/test_56/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_57/conf.json
+++ b/test/tests/test_57/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_58/conf.json
+++ b/test/tests/test_58/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_59/conf.json
+++ b/test/tests/test_59/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_6/conf.json
+++ b/test/tests/test_6/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_60/conf.json
+++ b/test/tests/test_60/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_61/conf.json
+++ b/test/tests/test_61/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_62/conf.json
+++ b/test/tests/test_62/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_63/conf.json
+++ b/test/tests/test_63/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_64/conf.json
+++ b/test/tests/test_64/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_65/conf.json
+++ b/test/tests/test_65/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_66/conf.json
+++ b/test/tests/test_66/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_67/conf.json
+++ b/test/tests/test_67/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_68/conf.json
+++ b/test/tests/test_68/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_69/conf.json
+++ b/test/tests/test_69/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_7/conf.json
+++ b/test/tests/test_7/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_70/conf.json
+++ b/test/tests/test_70/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_71/conf.json
+++ b/test/tests/test_71/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_72/conf.json
+++ b/test/tests/test_72/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_73/conf.json
+++ b/test/tests/test_73/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_74/conf.json
+++ b/test/tests/test_74/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_75/conf.json
+++ b/test/tests/test_75/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_76/conf.json
+++ b/test/tests/test_76/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_77/conf.json
+++ b/test/tests/test_77/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_78/conf.json
+++ b/test/tests/test_78/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_79/conf.json
+++ b/test/tests/test_79/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_8/conf.json
+++ b/test/tests/test_8/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_80/conf.json
+++ b/test/tests/test_80/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_81/conf.json
+++ b/test/tests/test_81/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_82/conf.json
+++ b/test/tests/test_82/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_83/conf.json
+++ b/test/tests/test_83/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_84/conf.json
+++ b/test/tests/test_84/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_85/conf.json
+++ b/test/tests/test_85/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_86/conf.json
+++ b/test/tests/test_86/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_87/conf.json
+++ b/test/tests/test_87/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_88/conf.json
+++ b/test/tests/test_88/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_89/conf.json
+++ b/test/tests/test_89/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_9/conf.json
+++ b/test/tests/test_9/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_90/conf.json
+++ b/test/tests/test_90/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_91/conf.json
+++ b/test/tests/test_91/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_92/conf.json
+++ b/test/tests/test_92/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_93/conf.json
+++ b/test/tests/test_93/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_94/conf.json
+++ b/test/tests/test_94/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_95/conf.json
+++ b/test/tests/test_95/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_96/conf.json
+++ b/test/tests/test_96/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_97/conf.json
+++ b/test/tests/test_97/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_98/conf.json
+++ b/test/tests/test_98/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": false,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }

--- a/test/tests/test_99/conf.json
+++ b/test/tests/test_99/conf.json
@@ -25,5 +25,6 @@
     },
     "has_norm_quant": true,
     "has_bias": true,
-    "has_relu": false
+    "has_relu": false,
+    "wmem": "tcdm"
 }


### PR DESCRIPTION
Change the `wmem` field to be required instead of optional and defaulting to tcdm because some accelerators might not support tcdm. E.g. atm 'siracusa_v2' does not support tcdm and the pydantic validator doesn't check it if the field is omitted in the json.